### PR TITLE
Remove UTF-8 character from common.pp

### DIFF
--- a/manifests/pam/common.pp
+++ b/manifests/pam/common.pp
@@ -4,7 +4,7 @@
 
 Common PAM requirements for googleauthenticator.
 
-It shouldn’t be necessary to directly include this class.
+It shouldn't be necessary to directly include this class.
 
 */
 


### PR DESCRIPTION
So file will work under puppet when running ruby 1.9 in LANG=C mode
