### PR TITLE
For RedHat based systems, use the default service name

### DIFF
--- a/manifests/pam/redhat.pp
+++ b/manifests/pam/redhat.pp
@@ -36,7 +36,7 @@ define googleauthenticator::pam::redhat(
       augeas {"Purge existing google-authenticator from ${name}":
         context => "/files/etc/pam.d/${name}",
         changes => 'rm include[. =~ regexp("google-authenticator.*")]',
-        notify  => Service['ssh'],
+        notify  => Service['sshd'],
       }
     }
     default: { fail("Wrong ensure value ${ensure}") }

--- a/manifests/pam/redhat.pp
+++ b/manifests/pam/redhat.pp
@@ -29,7 +29,7 @@ define googleauthenticator::pam::redhat(
           "set include[. = ''] '${rule}'",
           ],
         require => File["/etc/pam.d/${rule}"],
-        notify  => Service['ssh'],
+        notify  => Service['sshd'],
       }
     }
     'absent': {


### PR DESCRIPTION
On Debian based systems, the default service name "ssh" used in this module is correct. In the case of RedHat derived systems (RHEL, Centos, Fedora, etc), the service name is "sshd." This change allows an admin to work with the default name, and not need to redefine or duplicate the "sshd" service as "ssh" in order to support this module.
